### PR TITLE
Remove faster_whisper preload from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,11 +42,6 @@ EOF
 
 ARG WHISPER_MODEL=small
 ENV WHISPER_MODEL=${WHISPER_MODEL}
-RUN echo "Preloading faster_whisper model: ${WHISPER_MODEL}" && \
-    python - <<'EOF'
-import os, faster_whisper
-faster_whisper.WhisperModel(os.getenv('WHISPER_MODEL'), device='cpu')
-EOF
 
 RUN echo "Preloading SentenceFinishedClassification model..." && \
     python - <<'EOF'


### PR DESCRIPTION
## Summary
- avoid preloading faster_whisper during Docker build so model loads at runtime

## Testing
- `pytest`
- `docker build -t realtimevoicechat .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68a977fe632c8321b6ef3ddaa53d0c61