### PR TITLE
refactor: split Dockerfile into multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.10-slim
+ARG WHISPER_MODEL=small
+
+# ---------- Stage 1: builder ----------
+FROM python:3.10-slim AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -31,32 +34,76 @@ COPY --chown=1001:1001 code/ ./code/
 COPY --chown=1001:1001 entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+# Create non-root user and set cache locations
+RUN groupadd --gid 1001 appgroup && \
+    useradd --uid 1001 --gid 1001 --create-home appuser
+ENV HOME=/home/appuser
+ENV HF_HOME=${HOME}/.cache/huggingface
+ENV TORCH_HOME=${HOME}/.cache/torch
+ENV PYTHONUNBUFFERED=1
+ENV MAX_AUDIO_QUEUE_SIZE=50
+ENV LOG_LEVEL=INFO
+ENV RUNNING_IN_DOCKER=true
+ENV LLM_START_PROVIDER=ollama
+ENV LLM_START_MODEL=phi3-mini-4k-instruct-q4_k_m
+ENV WHISPER_MODEL=${WHISPER_MODEL}
+USER appuser
+
 # Pre-download models to speed up container startup
 RUN echo "Preloading Silero VAD model..." && \
-    python - <<'EOF'
+    python - <<'PYTHON'
 import torch, os
 cache_dir = os.path.expanduser("~/.cache/torch")
 os.environ['TORCH_HOME'] = cache_dir
 torch.hub.load('snakers4/silero-vad', 'silero_vad', onnx=False, trust_repo=True)
-EOF
-
-ARG WHISPER_MODEL=small
-ENV WHISPER_MODEL=${WHISPER_MODEL}
+PYTHON
 
 RUN echo "Preloading SentenceFinishedClassification model..." && \
-    python - <<'EOF'
+    python - <<'PYTHON'
 from transformers import DistilBertTokenizerFast, DistilBertForSequenceClassification
 DistilBertTokenizerFast.from_pretrained('KoljaB/SentenceFinishedClassification')
 DistilBertForSequenceClassification.from_pretrained('KoljaB/SentenceFinishedClassification')
-EOF
+PYTHON
 
 # Pull Ollama model during build
 RUN ollama pull phi3-mini-4k-instruct-q4_k_m
+
+
+# ---------- Stage 2: runtime ----------
+FROM python:3.10-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Runtime system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libsndfile1 \
+    libportaudio2 \
+    ffmpeg \
+    curl \
+    gosu \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Ollama runtime
+RUN curl -fsSL https://ollama.com/install.sh | sh
+
+# Set working directory for the application
+WORKDIR /app/code
 
 # Create non-root user
 RUN groupadd --gid 1001 appgroup && \
     useradd --uid 1001 --gid 1001 --create-home appuser
 
+# Copy installed Python packages from the builder stage
+RUN mkdir -p /usr/local/lib/python3.10/dist-packages
+COPY --chown=1001:1001 --from=builder /usr/local/lib/python3.10/dist-packages /usr/local/lib/python3.10/dist-packages
+
+# Copy application and caches from builder
+COPY --from=builder --chown=1001:1001 /app /app
+COPY --from=builder --chown=1001:1001 /entrypoint.sh /entrypoint.sh
+COPY --from=builder --chown=1001:1001 /home/appuser /home/appuser
+RUN chmod +x /entrypoint.sh
+
+# Environment variables
 ENV HOME=/home/appuser
 ENV PYTHONUNBUFFERED=1
 ENV MAX_AUDIO_QUEUE_SIZE=50
@@ -66,9 +113,10 @@ ENV HF_HOME=${HOME}/.cache/huggingface
 ENV TORCH_HOME=${HOME}/.cache/torch
 ENV LLM_START_PROVIDER=ollama
 ENV LLM_START_MODEL=phi3-mini-4k-instruct-q4_k_m
+ARG WHISPER_MODEL
+ENV WHISPER_MODEL=${WHISPER_MODEL}
 
 EXPOSE 8000
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["python", "-m", "uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]
-


### PR DESCRIPTION
## Summary
- restructure Dockerfile with separate builder and runtime stages
- preload models as appuser and copy caches into lean runtime image
- set runtime workdir to `/app/code` and copy built Python packages from builder

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a997cded3883219130193347b970b6