### PR TITLE
Handle missing LLM latency measurement

### DIFF
--- a/code/speech_pipeline_manager.py
+++ b/code/speech_pipeline_manager.py
@@ -169,7 +169,16 @@ class SpeechPipelineManager:
         )
         self.llm.prewarm()
         self.llm_inference_time = self.llm.measure_inference_time()
-        logger.debug(f"🗣️🧠🕒 LLM inference time: {self.llm_inference_time:.2f}ms")
+        if self.llm_inference_time is None:
+            logger.warning(
+                "🗣️🧠🕒 LLM inference time measurement failed; defaulting to 0.0ms."
+            )
+            self.llm_inference_time = 0.0
+            raise RuntimeError("LLM inference time measurement failed")
+        if self.llm_inference_time is not None:
+            logger.debug(
+                f"🗣️🧠🕒 LLM inference time: {self.llm_inference_time:.2f}ms"
+            )
 
         # --- State ---
         self.history = []


### PR DESCRIPTION
## Summary
- Warn and abort when LLM inference latency cannot be measured
- Guard debug logging to avoid formatting non-numeric inference time

## Testing
- `python -m py_compile code/speech_pipeline_manager.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9d03e81908321ab606a9e138d815e