### PR TITLE
Handle missing LLM inference timings gracefully

### DIFF
--- a/code/speech_pipeline_manager.py
+++ b/code/speech_pipeline_manager.py
@@ -185,7 +185,6 @@ class SpeechPipelineManager:
                     "🗣️🧠🕒 LLM inference time measurement failed; defaulting to 0.0ms.",
                 )
                 self.llm_inference_time = 0.0
-                raise RuntimeError("LLM inference time measurement failed")
             logger.debug(
                 f"🗣️🧠🕒 LLM inference time: {self.llm_inference_time:.2f}ms",
             )
@@ -230,8 +229,13 @@ class SpeechPipelineManager:
 
         self.on_partial_assistant_text: Optional[Callable[[str], None]] = None
 
-        self.full_output_pipeline_latency = self.llm_inference_time + self.audio.tts_inference_time
-        logger.info(f"🗣️⏱️ Full output pipeline latency: {self.full_output_pipeline_latency:.2f}ms (LLM: {self.llm_inference_time:.2f}ms, TTS: {self.audio.tts_inference_time:.2f}ms)")
+        self.full_output_pipeline_latency = (self.llm_inference_time or 0.0) + (
+            self.audio.tts_inference_time or 0.0
+        )
+        logger.info(
+            "🗣️⏱️ Full output pipeline latency: "
+            f"{self.full_output_pipeline_latency:.2f}ms (LLM: {(self.llm_inference_time or 0.0):.2f}ms, TTS: {(self.audio.tts_inference_time or 0.0):.2f}ms)"
+        )
 
         logger.info("🗣️🚀 SpeechPipelineManager initialized and workers started.")
 


### PR DESCRIPTION
## Summary
- Avoid raising runtime error when LLM inference timing cannot be measured
- Default LLM inference timing to 0ms and compute overall pipeline latency safely

## Testing
- `python -m py_compile code/speech_pipeline_manager.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9d59e500483218220c94f42ea0e7a