### PR TITLE
Enable VAD and add audio visualizer

### DIFF
--- a/code/static/app.js
+++ b/code/static/app.js
@@ -105,6 +105,10 @@ async function startRawPcmCapture() {
     await audioContext.audioWorklet.addModule('/static/pcmWorkletProcessor.js');
     micWorkletNode = new AudioWorkletNode(audioContext, 'pcm-worklet-processor');
 
+    if (window.AudioVisualizer) {
+      AudioVisualizer.start(audioContext, stream);
+    }
+
     micWorkletNode.port.onmessage = ({ data }) => {
       const incoming = new Int16Array(data);
       let read = 0;
@@ -173,6 +177,9 @@ function cleanupAudio() {
   if (ttsWorkletNode) {
     ttsWorkletNode.disconnect();
     ttsWorkletNode = null;
+  }
+  if (window.AudioVisualizer) {
+    AudioVisualizer.stop();
   }
   if (audioContext) {
     audioContext.close();

--- a/code/static/index.html
+++ b/code/static/index.html
@@ -222,6 +222,12 @@
       font-size: 0.8rem;
       color: #666;
     }
+    #visualizer {
+      width: 100%;
+      height: 150px;
+      display: block;
+      background: rgba(0,0,0,0.7);
+    }
   </style>
 </head>
 <body>
@@ -244,6 +250,7 @@
         Real-Time Voice Chat
         <span class="status" id="status"></span>
       </div>
+      <canvas id="visualizer"></canvas>
       <div class="messages" id="messages"></div>
       <div class="input-bar">
 
@@ -287,6 +294,8 @@
       </div>
     </div>
   </div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+  <script src="/static/visualizer.js"></script>
   <script src="/static/app.js"></script>
 </body>
 </html>

--- a/code/static/visualizer.js
+++ b/code/static/visualizer.js
@@ -1,0 +1,63 @@
+(function(){
+  class Visualizer {
+    constructor(){
+      this.analyser = null;
+      this.dataArray = null;
+      this.scene = null;
+      this.camera = null;
+      this.renderer = null;
+      this.bars = [];
+      this.animationId = null;
+    }
+    start(audioCtx, stream){
+      if (this.renderer) return; // already started
+      this.analyser = audioCtx.createAnalyser();
+      this.analyser.fftSize = 256;
+      const source = audioCtx.createMediaStreamSource(stream);
+      source.connect(this.analyser);
+      this.dataArray = new Uint8Array(this.analyser.frequencyBinCount);
+
+      const canvas = document.getElementById('visualizer');
+      const width = canvas.clientWidth;
+      const height = canvas.clientHeight;
+
+      this.renderer = new THREE.WebGLRenderer({canvas});
+      this.renderer.setSize(width, height);
+      this.scene = new THREE.Scene();
+      this.camera = new THREE.PerspectiveCamera(75, width/height, 0.1, 1000);
+      this.camera.position.z = 5;
+
+      const barCount = this.analyser.frequencyBinCount;
+      const spacing = 0.15;
+      for(let i=0;i<barCount;i++){
+        const geometry = new THREE.BoxGeometry(0.1,0.1,0.1);
+        const material = new THREE.MeshBasicMaterial({color:0x00ff00});
+        const bar = new THREE.Mesh(geometry, material);
+        bar.position.x = (i - barCount/2) * spacing;
+        this.scene.add(bar);
+        this.bars.push(bar);
+      }
+
+      const animate = () => {
+        this.analyser.getByteFrequencyData(this.dataArray);
+        for(let i=0;i<this.bars.length;i++){
+          const scale = (this.dataArray[i]/255)*2 + 0.1;
+          this.bars[i].scale.y = scale;
+        }
+        this.renderer.render(this.scene, this.camera);
+        this.animationId = requestAnimationFrame(animate);
+      };
+      animate();
+    }
+    stop(){
+      if(this.animationId) cancelAnimationFrame(this.animationId);
+      if(this.renderer){
+        this.renderer.dispose();
+        this.renderer = null;
+      }
+      this.bars = [];
+      this.analyser = null;
+    }
+  }
+  window.AudioVisualizer = new Visualizer();
+})();

--- a/code/transcribe.py
+++ b/code/transcribe.py
@@ -48,7 +48,7 @@ DEFAULT_RECORDER_CONFIG: Dict[str, Any] = {
     # Callbacks will be added dynamically in _create_recorder
     "debug_mode": True,
     "initial_prompt_realtime": "The sky is blue. When the sky... She walked home. Because he... Today is sunny. If only I...",
-    "faster_whisper_vad_filter": False,
+    "faster_whisper_vad_filter": True,
 }
 
 


### PR DESCRIPTION
## Summary
- enable faster-whisper VAD filter to pause agent queries on silence
- integrate a Three.js audio visualizer in the web UI
- hook visualizer start/stop into audio capture lifecycle

## Testing
- `python -m py_compile code/transcribe.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab4c60b688832188d7fc39a5bc64d4