### PR TITLE
Use logger for model download messages

### DIFF
--- a/code/audio_module.py
+++ b/code/audio_module.py
@@ -57,8 +57,7 @@ def ensure_lasinya_models(models_root: str = "models", model_name: str = "Lasiny
     for fn in files:
         local_file = os.path.join(base, fn)
         if not os.path.exists(local_file):
-            # Not using logger here as it might not be configured yet during module import/init
-            print(f"👄⏬ Downloading {fn} to {base}")
+            logger.info(f"👄⏬ Downloading {fn} to {base}")
             hf_hub_download(
                 repo_id="KoljaB/XTTS_Lasinya",
                 filename=fn,


### PR DESCRIPTION
## Summary
- Replace print statement in `ensure_lasinya_models` with `logger.info`
- Ensure module consistently uses the same logger for all messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abbeb84f348321b28cf3872605ced0