### PR TITLE
Document WebSocket endpoint and guide REST requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ Your application is already running via `docker compose up -d`! Check logs using
     python server.py
     ```
 
+**Important:** All interaction with the backend happens over a WebSocket at `/ws`. Traditional REST endpoints such as `/api/chat` are not implemented; HTTP requests to them will return a message directing you to the WebSocket route.
+
 **Accessing the Client (Both Methods):**
 
 1.  Open your web browser to `http://localhost:8000` (or your server's IP if running remotely/in Docker on another machine).

--- a/code/server.py
+++ b/code/server.py
@@ -175,6 +175,11 @@ async def get_index() -> HTMLResponse:
         html_content = f.read()
     return HTMLResponse(content=html_content)
 
+@app.api_route("/api/chat", methods=["GET", "POST"])
+async def rest_chat_redirect() -> dict:
+    """Inform clients that REST chat endpoints are not available."""
+    return {"detail": "Use the WebSocket endpoint at /ws for real-time chat"}
+
 # --------------------------------------------------------------------
 # Utility functions
 # --------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Document that all interaction happens over the WebSocket `/ws` and no REST chat endpoint exists
- Add `/api/chat` HTTP route that returns a message directing clients to `/ws`

## Testing
- `python -m py_compile code/server.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abc109039083219800a0725fe0472d