### PR TITLE
Avoid double import by passing app to uvicorn

### DIFF
--- a/code/server.py
+++ b/code/server.py
@@ -953,7 +953,7 @@ if __name__ == "__main__":
     # Run the server without SSL
     if not USE_SSL:
         logger.info("🖥️▶️ Starting server without SSL.")
-        uvicorn.run("server:app", host="0.0.0.0", port=8000, log_config=None)
+        uvicorn.run(app, host="0.0.0.0", port=8000, log_config=None)
 
     else:
         logger.info("🖥️🔒 Attempting to start server with SSL.")
@@ -972,7 +972,7 @@ if __name__ == "__main__":
         # Run the server with SSL
         logger.info(f"🖥️▶️ Starting server with SSL (cert: {cert_file}, key: {key_file}).")
         uvicorn.run(
-            "server:app",
+            app,
             host="0.0.0.0",
             port=8000,
             log_config=None,


### PR DESCRIPTION
## Summary
- Run the FastAPI server by passing the `app` instance directly to `uvicorn.run` to prevent re-imports

## Testing
- `python code/server.py` *(fails: ModuleNotFoundError: No module named 'torch')*
- `uvicorn server:app --app-dir code` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68abdc3000ac8321a36ffb67535088b3