### PR TITLE
refactor: remove global app reference in final answer callback

### DIFF
--- a/code/server.py
+++ b/code/server.py
@@ -886,7 +886,10 @@ class TranscriptionCallbacks:
                     "type": "final_assistant_answer",
                     "content": cleaned_answer
                 })
-                app.state.SpeechPipelineManager.history.append({"role": "assistant", "content": cleaned_answer})
+                self.app.state.SpeechPipelineManager.history.append({
+                    "role": "assistant",
+                    "content": cleaned_answer,
+                })
                 self.final_assistant_answer_sent = True
                 self.final_assistant_answer = cleaned_answer # Store the sent answer
             else:


### PR DESCRIPTION
## Summary
- use `self.app.state.SpeechPipelineManager` in `send_final_assistant_answer`
- avoid global `app` references within callback

## Testing
- `python -m py_compile code/server.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad4758d4e08321aacf6105646378a9