### PR TITLE
Ensure stop_tts resets ignore flag

### DIFF
--- a/code/static/app.js
+++ b/code/static/app.js
@@ -271,22 +271,16 @@ function handleJSONMessage({ type, content }) {
     }
     return;
   }
-  if (type === "tts_interruption") {
+  if (type === "tts_interruption" || type === "stop_tts") {
     if (ttsWorkletNode) {
       ttsWorkletNode.port.postMessage({ type: "clear" });
     }
     isTTSPlaying = false;
     ignoreIncomingTTS = false;
-    return;
-  }
-  if (type === "stop_tts") {
-    if (ttsWorkletNode) {
-      ttsWorkletNode.port.postMessage({ type: "clear" });
+    if (type === "stop_tts" && socket && socket.readyState === WebSocket.OPEN) {
+      console.log("TTS playback stopped. Reason: stop_tts.");
+      socket.send(JSON.stringify({ type: 'tts_stop' }));
     }
-    isTTSPlaying = false;
-    ignoreIncomingTTS = true;
-    console.log("TTS playback stopped. Reason: tts_interruption.");
-    socket.send(JSON.stringify({ type: 'tts_stop' }));
     return;
   }
 }


### PR DESCRIPTION
## Summary
- handle both `stop_tts` and `tts_interruption` in one block
- automatically reset `ignoreIncomingTTS` after server `stop_tts`

## Testing
- `node /tmp/test_stop_tts.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad480bfd488321b7281d1d144fbcf3