### PR TITLE
refactor: remove unused assistant answer variable

### DIFF
--- a/code/server.py
+++ b/code/server.py
@@ -507,10 +507,7 @@ async def send_tts_chunks(app: FastAPI, message_queue: asyncio.Queue, callbacks:
                 if not final_expected or audio_final_finished:
                     logger.info("🖥️🏁 Sending of TTS chunks and 'user request/assistant answer' cycle finished.")
                     callbacks.send_final_assistant_answer() # Callbacks method
-
-                    assistant_answer = app.state.SpeechPipelineManager.running_generation.quick_answer + app.state.SpeechPipelineManager.running_generation.final_answer
                     app.state.SpeechPipelineManager.running_generation = None
-
                     callbacks.tts_chunk_sent = False # Reset via callbacks
                     callbacks.reset_state() # Reset connection state via callbacks
 


### PR DESCRIPTION
## Summary
- remove unused assistant_answer variable in send_tts_chunks

## Testing
- `flake8 code/server.py` *(fails: command not found)*
- `python -m py_compile code/server.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad48fd543c83218bc2200757f45424