### PR TITLE
Log TTS playback chunks and stopping

### DIFF
--- a/code/static/ttsPlaybackProcessor.js
+++ b/code/static/ttsPlaybackProcessor.js
@@ -22,6 +22,7 @@ class TTSPlaybackProcessor extends AudioWorkletProcessor {
       // (You may also check here if event.data instanceof Int16Array if needed)
       this.bufferQueue.push(event.data);
       this.samplesRemaining += event.data.length;
+      console.log('Received chunk', event.data.length, 'samplesRemaining', this.samplesRemaining);
     };
   }
 
@@ -30,10 +31,12 @@ class TTSPlaybackProcessor extends AudioWorkletProcessor {
 
     if (this.samplesRemaining === 0) {
       outputChannel.fill(0);
+      const wasPlaying = this.isPlaying;
       if (this.isPlaying) {
         this.isPlaying = false;
         this.port.postMessage({ type: 'ttsPlaybackStopped' });
       }
+      console.log('samplesRemaining reached zero; isPlaying:', wasPlaying, '->', this.isPlaying);
       return true;
     }
 


### PR DESCRIPTION
## Summary
- log chunk length and remaining samples when receiving TTS audio
- log when playback stops because no samples remain

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad58a34364832192b84ec6802decfc