### PR TITLE
Handle ignoreIncomingTTS resets after speech events and ignored TTS chunks

### DIFF
--- a/code/static/app.js
+++ b/code/static/app.js
@@ -306,9 +306,20 @@ function handleJSONMessage({ type, content }) {
     renderMessages();
     return;
   }
+  if (type === "speech_start") {
+    ignoreIncomingTTS = true;
+    console.log(
+      `ignoreIncomingTTS set to true. Reason: ${type}. Reset in ${TTS_IGNORE_TIMEOUT_MS}ms unless interrupted.`
+    );
+    scheduleTTSIgnoreReset();
+    return;
+  }
   if (type === "tts_chunk") {
     if (ignoreIncomingTTS) {
-      console.log("Ignoring tts_chunk because ignoreIncomingTTS is true.");
+      console.log(
+        `Ignoring tts_chunk because ignoreIncomingTTS is true. Waiting ${TTS_IGNORE_TIMEOUT_MS}ms for tts_interruption before resetting.`
+      );
+      scheduleTTSIgnoreReset();
       return;
     }
     console.log("Processing tts_chunk.");


### PR DESCRIPTION
## Summary
- Set `ignoreIncomingTTS` and start timeout when `speech_start` is received from the server
- When ignoring `tts_chunk`, log the event and schedule a reset if no interruption arrives

## Testing
- `node --check code/static/app.js`
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68ad688bbec4832187d575a65552b2b8