### PR TITLE
Ensure final answer callback uses instance app state

### DIFF
--- a/code/server.py
+++ b/code/server.py
@@ -922,10 +922,11 @@ class TranscriptionCallbacks:
         """
         final_answer = ""
         # Access global manager state
-        if self.app.state.SpeechPipelineManager.is_valid_gen():
+        spm = self.app.state.SpeechPipelineManager
+        if spm.is_valid_gen():
             final_answer = (
-                self.app.state.SpeechPipelineManager.running_generation.quick_answer
-                + self.app.state.SpeechPipelineManager.running_generation.final_answer
+                spm.running_generation.quick_answer
+                + spm.running_generation.final_answer
             )
 
         if not final_answer:  # Check if constructed answer is empty
@@ -961,7 +962,7 @@ class TranscriptionCallbacks:
                     "type": "final_assistant_answer",
                     "content": cleaned_answer
                 })
-                self.app.state.SpeechPipelineManager.history.append({
+                spm.history.append({
                     "role": "assistant",
                     "content": cleaned_answer,
                 })


### PR DESCRIPTION
## Summary
- Refactor `send_final_assistant_answer` to pull application state from the callback instance
- Append assistant history using the locally cached speech pipeline manager

## Testing
- `python -m py_compile code/server.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad891e602c8321bf06898743b1f23a